### PR TITLE
fix: each frame invalidation for NDMF preview

### DIFF
--- a/Runtime/Component/Expression/FacialExpressionComponent.cs
+++ b/Runtime/Component/Expression/FacialExpressionComponent.cs
@@ -36,7 +36,7 @@ namespace com.aoyon.facetune
 
                     var blendShapeAnimations_ = FTAnimationUtility.FilterBlendShapeAnimations(GenericAnimation.FromAnimationClip(clip)).ToList();
                     var animationIndex = new AnimationIndex(blendShapeAnimations_);
-                    
+
                     var excludeOption = observeContext.Observe(this, c => c.ClipExcludeOption, (a, b) => a == b);
                     var defaultSet = defaultExpression.AnimationIndex.GetAllFirstFrameBlendShapeSet();
 

--- a/Runtime/Data/Expression.cs
+++ b/Runtime/Data/Expression.cs
@@ -20,7 +20,7 @@ internal class Expression : IEqualityComparer<Expression>
         _animationIndex = new AnimationIndex(animations);
         _facialSettings = settings;
     }
-    
+
     public void MergeExpression(Expression other)
     {
         MergeAnimation(other.Animations);
@@ -30,7 +30,7 @@ internal class Expression : IEqualityComparer<Expression>
     public void MergeFacialSettings(FacialSettings? other)
     {
         if (other == null) return;
-        
+
         if (_facialSettings == null) _facialSettings = FacialSettings.Keep;
 
         if (other.AllowEyeBlink != TrackingPermission.Keep)
@@ -49,7 +49,27 @@ internal class Expression : IEqualityComparer<Expression>
 
     public bool Equals(Expression x, Expression y)
     {
-        return x.Name == y.Name && x.Animations.SequenceEqual(y.Animations) && x.FacialSettings == y.FacialSettings;
+        return Expression.ValueEquals(x, y);
+    }
+    public static bool ValueEquals(Expression x, Expression y)
+    {
+        if (x.Name != y.Name) { return false; }
+        if (x.FacialSettings != y.FacialSettings) { return false; }
+
+        var xAni = x.Animations;
+        var yAni = y.Animations;
+
+        if (xAni.Count != yAni.Count) { return false; }
+
+        for (var i = 0; xAni.Count > i; i += 1)
+        {
+            var xa = xAni[i];
+            var ya = yAni[i];
+
+            var isDifferent = xa.ValueEquals(ya) is false;
+            if (isDifferent) { return false; }
+        }
+        return true;
     }
 
     public int GetHashCode(Expression obj)

--- a/Runtime/SerializableData/FacialSettings.cs
+++ b/Runtime/SerializableData/FacialSettings.cs
@@ -7,7 +7,7 @@ public record class FacialSettings
     public TrackingPermission AllowLipSync;
 
     public BlendingPermission BlendingPermission;
-    
+
     public FacialSettings()
     {
         AllowEyeBlink = TrackingPermission.Disallow;
@@ -23,4 +23,5 @@ public record class FacialSettings
     }
 
     internal static FacialSettings Keep = new FacialSettings(TrackingPermission.Keep, TrackingPermission.Keep, BlendingPermission.Keep);
+
 }

--- a/Runtime/SerializableData/GenericAnimation.cs
+++ b/Runtime/SerializableData/GenericAnimation.cs
@@ -21,21 +21,21 @@ public record GenericAnimation // Immutable
 
     public GenericAnimation(SerializableCurveBinding curveBinding, AnimationCurve curve)
     {
-        _curveBinding = curveBinding with {};
+        _curveBinding = curveBinding with { };
         _curve = curve.Clone();
         _objectReferenceCurve = new();
     }
 
     public GenericAnimation(SerializableCurveBinding curveBinding, IEnumerable<SerializableObjectReferenceKeyframe> objectReferenceCurve)
     {
-        _curveBinding = curveBinding with {};
+        _curveBinding = curveBinding with { };
         _curve = new();
         _objectReferenceCurve = objectReferenceCurve.ToList();
     }
 
     public GenericAnimation(SerializableCurveBinding curveBinding, AnimationCurve curve, IEnumerable<SerializableObjectReferenceKeyframe> objectReferenceCurve)
     {
-        _curveBinding = curveBinding with {};
+        _curveBinding = curveBinding with { };
         _curve = curve.Clone();
         _objectReferenceCurve = objectReferenceCurve.ToList();
     }
@@ -61,4 +61,14 @@ public record GenericAnimation // Immutable
         return animations;
     }
 #endif
+
+    // こんなのが必要になる時点で record である意義はあるのだろうか ?
+    public bool ValueEquals(GenericAnimation? other)
+    {
+        if (other is null) { return false; }
+        if (_curveBinding.ValueEquals(other._curveBinding) is false) { return false; }
+        if (_objectReferenceCurve.SequenceEqual(other._objectReferenceCurve) is false) { return false; }
+        if (_curve.keys.SequenceEqual(other._curve.keys) is false) { return false; }
+        return true;
+    }
 }

--- a/Runtime/SerializableData/SerializableCurveBinding.cs
+++ b/Runtime/SerializableData/SerializableCurveBinding.cs
@@ -14,7 +14,7 @@ public record SerializableCurveBinding // Immutable
 
     [SerializeField] private bool _isPPtrCurve;
     public bool IsPPtrCurve { get => _isPPtrCurve; init => _isPPtrCurve = value; }
-    
+
     [SerializeField] private bool _isDiscreteCurve;
     public bool IsDiscreteCurve { get => _isDiscreteCurve; init => _isDiscreteCurve = value; }
 
@@ -34,7 +34,7 @@ public record SerializableCurveBinding // Immutable
         _isPPtrCurve = isPPtrCurve;
         _isDiscreteCurve = isDiscreteCurve;
     }
-    
+
     public static SerializableCurveBinding FloatCurve(string path, Type type, string propertyName)
     {
         return new SerializableCurveBinding(path, type, propertyName, false, false);
@@ -49,21 +49,21 @@ public record SerializableCurveBinding // Immutable
     {
         return new SerializableCurveBinding(path, type, propertyName, false, true);
     }
-    
+
 #if UNITY_EDITOR
     public static SerializableCurveBinding FromEditorCurveBinding(UnityEditor.EditorCurveBinding binding)
     {
         return new SerializableCurveBinding(
-            binding.path, 
-            binding.type, 
-            binding.propertyName, 
-            binding.isPPtrCurve, 
+            binding.path,
+            binding.type,
+            binding.propertyName,
+            binding.isPPtrCurve,
             binding.isDiscreteCurve
         );
     }
 
     public UnityEditor.EditorCurveBinding ToEditorCurveBinding()
-    {   
+    {
         if (IsDiscreteCurve)
         {
             return UnityEditor.EditorCurveBinding.DiscreteCurve(Path, Type, PropertyName);
@@ -78,4 +78,14 @@ public record SerializableCurveBinding // Immutable
         }
     }
 #endif
+
+    public bool ValueEquals(SerializableCurveBinding other)
+    {
+        if (_path != other._path) { return false; }
+        if (_type.Name != other._type.Name) { return false; }
+        if (_propertyName != other._propertyName) { return false; }
+        if (_isPPtrCurve != other._isPPtrCurve) { return false; }
+        if (_isDiscreteCurve != other._isDiscreteCurve) { return false; }
+        return true;
+    }
 }

--- a/Runtime/SerializableData/SerializableObjectReferenceKeyframe.cs
+++ b/Runtime/SerializableData/SerializableObjectReferenceKeyframe.cs
@@ -31,4 +31,11 @@ public struct SerializableObjectReferenceKeyframe // Immutable
         };
     }
 #endif
+
+    public override bool Equals(object obj)
+    {
+        if (obj is not SerializableObjectReferenceKeyframe o) { return false; }
+        if (Mathf.Approximately(_time, o._time) is false) { return false; }
+        return _value == o._value;
+    }
 }


### PR DESCRIPTION
なんか、適当なブランチでつくっちゃったのゆるして

- struct の SerializableType の 等価性を調べる場合、 bit的に同値かどうかを調べる struct のデフォルト実装は string という 参照型 が存在すると使えなくなるっぽい ... ?
- recore(class) SerializableCurveBinding も SerializableType につられている様子で正しく等価性が判定できていなかった
- Expression には IEqualityComparer<T> が実装されているが、observeContext.Observe のときに Object.Equals を呼んでしまっていて意味がなくなっている
- 多分関係ないけど GetComponents は ComputeContext にあるのでそれを使うように変えた
- GenericAnimation._curve は毎度クローンされていて参照の同一性では判定できない、AnimationCurve は unity の native への ptr 持ってるからあんまりこれの bit 的な同値判定は信用ならない気がする。Keyframe は純粋な struct で bit 喉内で良さそうだから AnimationCurve.Keys の equal を呼ぶようにした。

とりあえずこんな感じに、同一参照を調べてそうなところ全部潰したらどうにかなったよ ... とりあえず適当にいじくり回したものだから、このコードを使用するかどうかは委ねる