### PR TITLE
fix: forget to use addMMDLayerControl

### DIFF
--- a/Editor/Animator/AnimatorInstaller.cs
+++ b/Editor/Animator/AnimatorInstaller.cs
@@ -62,7 +62,7 @@ internal class AnimatorInstaller : InstallerBase
 
     private void CreateInitializationLayer(PatternData patternData, int priority)
     {
-        var nonMMDLayer = AddLayer("Initial", priority, false);
+        var nonMMDLayer = AddLayer("Initial", priority, true);
         var nonMMDState = AddState(nonMMDLayer, "Initial", position: ExclusiveStatePosition);
         _nonMMDInitializationClip = nonMMDState.CreateClip(nonMMDState.Name);
 


### PR DESCRIPTION
これが正しいのかはちょっとわからないのだけど ... 

ショコラの AFK はアクションレイヤー側で表情を制御する作りになっていて、FX レイヤーの index 1 と 2 を無効化する仕様によって MA の MMD 対応が発火するからそこで FaceTune もInitial レイヤーがすべて無効化されてないと反映されなかったから MMD 対応時に無効化されるように変えてみたよ

参考 (2番目の動画) : https://misskey.niri.la/notes/afkondw8q4