### PR TITLE
refactor(preview): remove unnecessary Distinct() when iterating avatar roots

### DIFF
--- a/Editor/Preview/NDMFPreview/AbstractFaceTunePreview.cs
+++ b/Editor/Preview/NDMFPreview/AbstractFaceTunePreview.cs
@@ -27,9 +27,7 @@ internal abstract class AbstractFaceTunePreview<TFilter> : IRenderFilter where T
         using var _ = new ProfilingSampleScope($"{typeof(TFilter).Name}.GetTargetGroups");
         var groups = new List<RenderGroup>();
         var observeContext = new NDMFPreviewObserveContext(context);
-
-        // VRC Avatar DescriptorとNDMF Avatar Rootが別々のアバターとして認識され、rootに同じアバターが入るのを防ぐためのDistinct()です
-        foreach (var root in context.GetAvatarRoots().Distinct())
+        foreach (var root in context.GetAvatarRoots())
         {
             if (!context.ActiveInHierarchy(root)) continue;
             if (!AvatarContextBuilder.TryGetFaceRenderer(root, out var faceRenderer, out var bodyPath, null, observeContext)) continue;


### PR DESCRIPTION
- remove redundant `Distinct()` from `context.GetAvatarRoots()`
- remove obsolete comment about duplicate avatar recognition

NDMF v1.12.0で `GetTargetRoots()` の重複に関する処理が実装されたため、削除しました。
https://github.com/bdunderscore/ndmf/releases/tag/1.12.0