### PR TITLE
fix(migration): migrate MA Menu Item expressions to DirectMenuEnabled

### DIFF
--- a/Editor.Importer/Aoyon.FaceTune.Editor.Importer.asmdef
+++ b/Editor.Importer/Aoyon.FaceTune.Editor.Importer.asmdef
@@ -8,7 +8,8 @@
         "jp.suzuryg.face-emo.components.Runtime",
         "jp.suzuryg.face-emo.domain.Runtime",
         "nadena.dev.ndmf",
-        "nadena.dev.ndmf.runtime"
+        "nadena.dev.ndmf.runtime",
+        "nadena.dev.modular-avatar.core"
     ],
     "includePlatforms": [
         "Editor"

--- a/Editor.Importer/Legacy/LegacyFaceTuneImporter.cs
+++ b/Editor.Importer/Legacy/LegacyFaceTuneImporter.cs
@@ -291,31 +291,35 @@ internal sealed class LegacyFaceTuneImporter
 
         var localConditions = source.GetComponents<LegacyConditionComponent>();
         var hasLocalConditions = localConditions.Length > 0 && localConditions.All(condition => !IsEmpty(condition));
-        var legacyMenuItem = source.GetComponent<ModularAvatarMenuItem>();
 
-        if (!hasLocalConditions && legacyMenuItem is { PortableControl.Type: PortableControlType.Toggle })
-        {
-            target.DirectMenuEnabled = true;
-            if (legacyMenuItem.PortableControl.Icon != null)
-            {
-                target.DirectMenuSettings.Menu.Icon.Mode = MenuIconSettings.Kind.Manual;
-                target.DirectMenuSettings.Menu.Icon.ManualIcon = legacyMenuItem.PortableControl.Icon;
-            }
-            return;
-        }
+        var isMenuItemImported = TryImportLegacyMenuItem(source, target);
 
         target.HasCondition = true;
-        if (!hasLocalConditions)
-        {
-            target.Condition.Mode = ConditionSelection.Kind.Always;
-            target.Condition.Condition = new Condition();
-        }
-        else
+        if (hasLocalConditions)
         {
             target.Condition.Mode = ConditionSelection.Kind.Conditional;
             target.Condition.Condition = new Condition(
                 localConditions.Select(ToConditionCase).ToArray());
         }
+        else if (!isMenuItemImported)
+        {
+            target.Condition.Mode = ConditionSelection.Kind.Always;
+            target.Condition.Condition = new Condition();
+        }
+    }
+    private static bool TryImportLegacyMenuItem(LegacyExpressionComponent source, ExpressionComponent target)
+    {
+        if (!source.TryGetComponent<ModularAvatarMenuItem>(out var legacyMenuItem)) return false;
+        if (legacyMenuItem.PortableControl.Type != PortableControlType.Toggle) return false;
+
+        target.DirectMenuEnabled = true;
+        if (legacyMenuItem.PortableControl.Icon != null)
+        {
+            target.DirectMenuSettings.Menu.Icon.Mode = MenuIconSettings.Kind.Manual;
+            target.DirectMenuSettings.Menu.Icon.ManualIcon = legacyMenuItem.PortableControl.Icon;
+        }
+
+        return true;
     }
 
     private void ImportExpressionData(

--- a/Editor.Importer/Legacy/LegacyFaceTuneImporter.cs
+++ b/Editor.Importer/Legacy/LegacyFaceTuneImporter.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CS0618
 
 using System.IO;
+using nadena.dev.modular_avatar.core;
 
 namespace Aoyon.FaceTune.Importers.Legacy;
 
@@ -289,9 +290,22 @@ internal sealed class LegacyFaceTuneImporter
         target.AlwaysOnPreviewEnabled = source.EnableRealTimePreview;
 
         var localConditions = source.GetComponents<LegacyConditionComponent>();
+        var hasLocalConditions = localConditions.Length > 0 && localConditions.All(condition => !IsEmpty(condition));
+        var legacyMenuItem = source.GetComponent<ModularAvatarMenuItem>();
+
+        if (!hasLocalConditions && legacyMenuItem is { PortableControl.Type: PortableControlType.Toggle })
+        {
+            target.DirectMenuEnabled = true;
+            if (legacyMenuItem.PortableControl.Icon != null)
+            {
+                target.DirectMenuSettings.Menu.Icon.Mode = MenuIconSettings.Kind.Manual;
+                target.DirectMenuSettings.Menu.Icon.ManualIcon = legacyMenuItem.PortableControl.Icon;
+            }
+            return;
+        }
+
         target.HasCondition = true;
-        if (localConditions.Length == 0
-            || localConditions.Any(condition => IsEmpty(condition)))
+        if (!hasLocalConditions)
         {
             target.Condition.Mode = ConditionSelection.Kind.Always;
             target.Condition.Condition = new Condition();


### PR DESCRIPTION
Fixes #152 

LocalConditionsが無い + MA Menu Itemsがあった場合は、`HasCondition` ではなく、`DirectMenuEnabled` を有効にしています。

legacyMenuItemがToggleだった場合に移行し、そのMenuItemにアイコンが設定されていたら移行されるようにしています。
もしどこか間違っていたら教えてください。